### PR TITLE
missing a space between 'Meriadoc' and 'Brandybuck'

### DIFF
--- a/jwe/5_10.including_additional_authentication_data.json
+++ b/jwe/5_10.including_additional_authentication_data.json
@@ -10,7 +10,7 @@
     },
     "alg": "A128KW",
     "enc": "A128GCM",
-    "aad": "[\"vcard\",[[\"version\",{},\"text\",\"4.0\"],[\"fn\",{},\"text\",\"MeriadocBrandybuck\"],[\"n\",{},\"text\",[\"Brandybuck\",\"Meriadoc\",\"Mr.\",\"\"]],[\"bday\",{},\"text\",\"TA2982\"],[\"gender\",{},\"text\",\"M\"]]]"
+    "aad": "[\"vcard\",[[\"version\",{},\"text\",\"4.0\"],[\"fn\",{},\"text\",\"Meriadoc Brandybuck\"],[\"n\",{},\"text\",[\"Brandybuck\",\"Meriadoc\",\"Mr.\",\"\"]],[\"bday\",{},\"text\",\"TA2982\"],[\"gender\",{},\"text\",\"M\"]]]"
   },
   "generated": {
     "cek": "75m1ALsYv10pZTKPWrsqdg",


### PR DESCRIPTION
Found by Jim Schaad